### PR TITLE
Added support for power on/off

### DIFF
--- a/LEDStripController/BLEClass.py
+++ b/LEDStripController/BLEClass.py
@@ -59,6 +59,18 @@ class QBleakClient(QObject):
             except Exception as inst:
                 print(inst)
 
+    async def writePower(self, state):
+            lista = [204, 35, 51]
+            if state == "Off":
+                lista = [204, 36, 51]
+
+            values = bytearray(lista)
+            try:
+                Utils.printLog("Change Power called Power : {}".format(state))
+                await self.client.write_gatt_char(UART_TX_CHAR_UUID, values, False)
+            except Exception as inst:
+                print(inst)
+
     async def writeMode(self, idx):
 
             #new byte[] { 256 - 69, mode, (byte)(speed & 0xFF), 68 };

--- a/LEDStripController/pyhl.py
+++ b/LEDStripController/pyhl.py
@@ -60,6 +60,16 @@ class MainWindow(QMainWindow):
         self.scan_button.setText("Scan")
         self.scan_button.setGeometry(QRect(10, 10, 75, 23))
 
+        self.powerOn_button = QPushButton(self)
+        self.powerOn_button.setText("Power On")
+        self.powerOn_button.setGeometry(QRect(10, 65, 75, 23))
+        self.powerOn_button.clicked.connect(self.changePowerToOn)
+
+        self.powerOff_button = QPushButton(self)
+        self.powerOff_button.setText("Power Off")
+        self.powerOff_button.setGeometry(QRect(85, 65, 75, 23))
+        self.powerOff_button.clicked.connect(self.changePowerToOff)
+
         self.connect_button = QPushButton(self)
         self.connect_button.setText("Connect")
         self.connect_button.setGeometry(QRect(10, 40, 75, 23))
@@ -231,6 +241,20 @@ class MainWindow(QMainWindow):
         Utils.Speed = value
         if isModeUsed:
             self.handle_mode(self.modeList.currentIndex().row())
+
+    def changePowerToOn(self):
+        self.handle_powerOn()
+
+    def changePowerToOff(self):
+        self.handle_powerOff()
+
+    @qasync.asyncSlot()
+    async def handle_powerOff(self):
+        await self.current_client.writePower("Off")
+
+    @qasync.asyncSlot()
+    async def handle_powerOn(self):
+        await self.current_client.writePower("On")
 
     def handle_enabledisable(self):
         whois = self.sender().text()


### PR DESCRIPTION
One of the main reasons I was searching for a PC controller for the LED strips was so that I could turn them on/off remotely with my PC's Bluetooth. I am very glad I found your repository. I added code for turning the strips on/off with help from https://github.com/madhead/saberlight/blob/master/app/commands/power.go

The code currently uses two buttons, but they could easily be replaced by a toggle. Let me know if this helps. Cheers!