### PR TITLE
Nogui

### DIFF
--- a/LEDStripController/BLEClass.py
+++ b/LEDStripController/BLEClass.py
@@ -59,6 +59,18 @@ class QBleakClient(QObject):
             except Exception as inst:
                 print(inst)
 
+    async def writePower(self, state):
+            lista = [204, 35, 51]
+            if state == "Off":
+                lista = [204, 36, 51]
+
+            values = bytearray(lista)
+            try:
+                Utils.printLog("Change Power called Power : {}".format(state))
+                await self.client.write_gatt_char(UART_TX_CHAR_UUID, values, False)
+            except Exception as inst:
+                print(inst)
+
     async def writeMode(self, idx):
 
             #new byte[] { 256 - 69, mode, (byte)(speed & 0xFF), 68 };

--- a/LEDStripController/Utils.py
+++ b/LEDStripController/Utils.py
@@ -1,7 +1,7 @@
 import os
 import pyaudio
 
-DEBUG_LOGS = False
+DEBUG_LOGS = True
 Modes = [37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 
          47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 
          97, 98, 99]

--- a/LEDStripController/cmdver.py
+++ b/LEDStripController/cmdver.py
@@ -1,18 +1,18 @@
 from bleak import BleakScanner, BleakClient
 import asyncio
-import ExternalAudio
+#import ExternalAudio
 import BLEClass
 import Utils
 
 devices = []
 
-async def handle_scan():
+async def handle_scan(all):
     global devices
     devices = await BLEClass.BleakScanner.discover()
     devices.extend(devices)
     x = 0
     for i, device in enumerate(devices):
-        if str(device.name).startswith("QHM"):
+        if str(device.name).startswith("QHM") or all:
             print(("{}) Device: {} Address: {}".format(x, device.name, device.address)))
             x+=1
 
@@ -23,10 +23,10 @@ async def handle_writeColor():
 
     Utils.isModeUsed = False
     try:
-        Utils.Colors["Red"] = input("Red (1-255):")
-        Utils.Colors["Green"] = input("Green (1-255):")
-        Utils.Colors["Blue"] = input("Blue (1-255):")
-        await current_client.writeColor()
+        Utils.Colors["Red"] = int(input("Red (1-255):"))
+        Utils.Colors["Green"] = int(input("Green (1-255):"))
+        Utils.Colors["Blue"] = int(input("Blue (1-255):"))
+        await current_client().writeColor()
     except Exception as ex:
         Utils.printLog("Colors error {}".format(ex))
 
@@ -50,11 +50,16 @@ async def main():
     while True:
         cmd = input("()> ")
         if (cmd == "scan"):
-            future = asyncio.ensure_future(handle_scan())
+            future = asyncio.ensure_future(handle_scan(False))
             await asyncio.wait({future}, return_when=asyncio.ALL_COMPLETED)
 
+        if (cmd == "scan *"):
+            future = asyncio.ensure_future(handle_scan(True))
+            await asyncio.wait({future}, return_when=asyncio.ALL_COMPLETED)
+            
         if (cmd == "connect"):
-            future = asyncio.ensure_future(handle_connect(0))
+            selection=int(input("Select Device >"))
+            future = asyncio.ensure_future(handle_connect(selection))
             await asyncio.wait({future}, return_when=asyncio.ALL_COMPLETED)
 
         if (cmd == "color"):

--- a/LEDStripController/cmdver.py
+++ b/LEDStripController/cmdver.py
@@ -1,10 +1,16 @@
 from bleak import BleakScanner, BleakClient
 import asyncio
-#import ExternalAudio
+import ExternalAudio
 import BLEClass
 import Utils
 
 devices = []
+
+reset="\x1b[1;0m"
+red="\x1b[1;31m"
+yellow="\x1b[1;33m"
+green="\x1b[1;32m"
+gray="\x1b[1;90m"
 
 async def handle_scan(all):
     global devices
@@ -45,6 +51,16 @@ async def handle_writeColor():
     except Exception as ex:
         Utils.printLog("Colors error {}".format(ex))
 
+async def handle_power(turnOn):
+    try:
+        if turnOn:
+            await current_client().writePower("On")
+        else:
+            await current_client().writePower("Off")
+
+    except Exception as ex:
+        Utils.printLog("Power error {}".format(ex))
+
 def handle_message_changed(message):
     pass
 
@@ -64,11 +80,46 @@ async def handle_connect(select):
 async def main():
     while True:
         cmd = input("()> ")
+        if (cmd == "help"):
+            print("")
+            print("scan")
+            print("  scans for devices with name starting with QHM")
+            print("")
+            print("scan *")
+            print("OR")
+            print("scanall")
+            print("  scans for all devices")
+            print("")
+            print("filter")
+            print("OR")
+            print("filter 00:00:00:00:00:00")
+            print("  filter devices by mac address")
+            print("")
+            print("ls")
+            print("OR")
+            print("list")
+            print("  list known devices")
+            print("")
+            print("connect")
+            print("  connect to a device")
+            print("")
+            print("color")
+            print("  send a color")
+            print("")
+            print("on")
+            print("  turn on lights")
+            print("")
+            print("off")
+            print("  turn off lights")
+            print("")
+            print("quit")
+            print("  quit program gracefully")
+            
         if (cmd == "scan"):
             future = asyncio.ensure_future(handle_scan(False))
             await asyncio.wait({future}, return_when=asyncio.ALL_COMPLETED)
             
-        if (cmd == "scan *"):
+        if (cmd == "scan *" or cmd == "scanall"):
             future = asyncio.ensure_future(handle_scan(True))
             await asyncio.wait({future}, return_when=asyncio.ALL_COMPLETED)
 
@@ -94,8 +145,19 @@ async def main():
                 future = asyncio.ensure_future(handle_connect(selection))
                 await asyncio.wait({future}, return_when=asyncio.ALL_COMPLETED)
 
+        if (cmd == "on"):
+            future = asyncio.ensure_future(handle_power(True))
+            await asyncio.wait({future}, return_when=asyncio.ALL_COMPLETED)
+
+        if (cmd == "off"):
+            future = asyncio.ensure_future(handle_power(False))
+            await asyncio.wait({future}, return_when=asyncio.ALL_COMPLETED)
+            
         if (cmd == "color"):
             future = asyncio.ensure_future(handle_writeColor())
             await asyncio.wait({future}, return_when=asyncio.ALL_COMPLETED)
+
+        if (cmd == "quit"):
+            quit()
 
 asyncio.run(main())


### PR DESCRIPTION
- fix for color function
- in scan: fixed list duplication and QHM filtering (it now actually removes non-QHM), added an "all" mode because Bleak has issues with device names sometimes on windows apparently and I'm affected by it
- Added handle_ls and ls cmd: lists the current devices known from scan
- Added handle_macfilter and filter cmd: Filters known device list based on provided mac filter
- Modified Connect cmd: It only triggers if there are known devices, and if there are more than 0 it asks which in the list to connect to by index
- Bringing BLEClass up-to-date to implement power control (lazy copy-paste of BLEClass.py  from main, tbh, but things still seem happy). 
- Added help function. 
- Added quit function. 
- Added on and off. 
- Brought in some color codes for console text color for prettier output but not sure how they'll play with windows cmd prompt. Linux terminal should like them fine
- adds support for setting the color of the color command in the command call (no more prompts), adds support for command sequence splicing. For example (epilepsy warning, no delays here):
```
scan;connect;on;color 0,0,255;wait;color 128,255,255;wait;color 255,0,0;wait;off;quit
```
- adds wait command, you can add delays between operations in command strings
- you can now call /c "command string" at the command line to execute a command string - for instance:

```
python .\cmdver.py /c "scan;connect;on;color 0,0,255;wait;color 128,255,255;wait;color 255,0,0;wait;off;quit"
```